### PR TITLE
Add support for option format: json, json_lines

### DIFF
--- a/configuration_example.yml
+++ b/configuration_example.yml
@@ -9,6 +9,7 @@
 #    proxy_url: "xyz"
 #    loadbalance: true
 #    compression_level: 9
+#    format: "json_lines"
 #    max_retries: 3
 #    timeout: 90 seconds
 #    tls:

--- a/http/config.go
+++ b/http/config.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"time"
+	"fmt"
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 )
@@ -23,6 +24,7 @@ type httpConfig struct {
 	Headers          map[string]string `config:"headers"`
 	ContentType      string            `config:"content_type"`
 	Backoff          backoff           `config:"backoff"`
+	Format           string            `config:"format"`
 }
 
 type backoff struct {
@@ -49,6 +51,7 @@ var (
 			Init: 1 * time.Second,
 			Max:  60 * time.Second,
 		},
+		Format:           "json",
 	}
 )
 
@@ -57,6 +60,9 @@ func (c *httpConfig) Validate() error {
 		if _, err := parseProxyURL(c.ProxyURL); err != nil {
 			return err
 		}
+	}
+	if c.Format != "json" && c.Format != "json_lines" {
+		return fmt.Errorf("Unsupported config option format: %s", c.Format)
 	}
 
 	return nil

--- a/http/http.go
+++ b/http/http.go
@@ -73,6 +73,7 @@ func MakeHTTP(
 			BatchPublish:     config.BatchPublish,
 			Headers:          config.Headers,
 			ContentType:      config.ContentType,
+			Format:           config.Format,
 		})
 
 		if err != nil {


### PR DESCRIPTION
By default, the `format: json` is fully backward compatible.
But the new `format: json_lines` do the same thing as the same option in [FluentBit HTTP output](https://docs.fluentbit.io/manual/pipeline/outputs/http).