### PR TITLE
Update libraries according to upstream changes

### DIFF
--- a/http/config.go
+++ b/http/config.go
@@ -1,10 +1,10 @@
 package http
 
 import (
-	"time"
 	"fmt"
+	"time"
 
-	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
+	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
 
 type httpConfig struct {
@@ -51,7 +51,7 @@ var (
 			Init: 1 * time.Second,
 			Max:  60 * time.Second,
 		},
-		Format:           "json",
+		Format: "json",
 	}
 )
 

--- a/http/http.go
+++ b/http/http.go
@@ -2,11 +2,13 @@ package http
 
 import (
 	"errors"
+
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/outputs"
-	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
+	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
 
 func init() {
@@ -25,7 +27,7 @@ func MakeHTTP(
 	_ outputs.IndexManager,
 	beat beat.Info,
 	observer outputs.Observer,
-	cfg *common.Config,
+	cfg *conf.C,
 ) (outputs.Group, error) {
 	config := defaultConfig
 	if err := cfg.Unpack(&config); err != nil {


### PR DESCRIPTION
Hi.
According to the latest changes in beats src code like [commit](https://github.com/elastic/beats/commit/5129d6ce91e37cc0df6c8c51ace7ccabb7db97db#diff-2429397ba9f6c560c26cb507ff7ea9dab5f16086ad2d886a10ee0ae795d296db) 
 this HTTP output producer for the Elastic Beats need to be updated to the latest changes.

This commit will update the output-http libraries and related breaking changes and
Synced with the latest filebeat version 8

```
filebeat version 8.10.0 (arm64), libbeat 8.10.0 [unknown built unknown]
```


